### PR TITLE
Ability to choose a video gallery

### DIFF
--- a/src/Controller/VideoAdmin.php
+++ b/src/Controller/VideoAdmin.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace NSWDPC\Elemental\Models\FeaturedVideo;
+
+use SilverStripe\Admin\ModelAdmin;
+
+/**
+ * Manage gallery videos
+ * @author james.ellis@dpc.nsw.gov.au
+ */
+class VideoAdmin extends ModelAdmin
+{
+    private static $url_segment = 'gallery-video';
+    private static $menu_title = 'Video';
+    private static $menu_icon_class = 'font-icon-block-media';
+    private static $managed_models = [
+        GalleryVideo::class
+    ];
+
+    public function getList()
+    {
+        $list = parent::getList();
+        $list = $list->sort(['Title' => 'ASC']);
+        return $list;
+    }
+
+}

--- a/src/Controller/VideoAdmin.php
+++ b/src/Controller/VideoAdmin.php
@@ -10,13 +10,31 @@ use SilverStripe\Admin\ModelAdmin;
  */
 class VideoAdmin extends ModelAdmin
 {
+    /**
+     * @var string
+     */
     private static $url_segment = 'gallery-video';
-    private static $menu_title = 'Video';
+
+    /**
+     * @var string
+     */
+    private static $menu_title = 'Videos';
+
+    /**
+     * @var string
+     */
     private static $menu_icon_class = 'font-icon-block-media';
+
+    /**
+     * @var array
+     */
     private static $managed_models = [
         GalleryVideo::class
     ];
 
+    /**
+     * @return DataList
+     */
     public function getList()
     {
         $list = parent::getList();

--- a/src/Models/Elements/ElementVideoGallery.php
+++ b/src/Models/Elements/ElementVideoGallery.php
@@ -47,6 +47,14 @@ class ElementVideoGallery extends ElementContent {
         'Videos'
     ];
 
+    public function DropdownTitle() {
+        $title = $this->Title;
+        if(!$title) {
+            $title = $this->getType();
+        }
+        return "{$title} (#{$this->ID})";
+    }
+
     public function getCMSFields()
     {
 

--- a/src/Models/Elements/ElementVideoGallery.php
+++ b/src/Models/Elements/ElementVideoGallery.php
@@ -47,12 +47,29 @@ class ElementVideoGallery extends ElementContent {
         'Videos'
     ];
 
-    public function DropdownTitle() {
+    /**
+     * Return a title for a dropdown to assist in identifying this gallery
+     * @return string
+     */
+    public function DropdownTitle() : string {
         $title = $this->Title;
         if(!$title) {
             $title = $this->getType();
         }
-        return "{$title} (#{$this->ID})";
+        $page = $this->getPage();
+        $suffix = "";
+        if($page && $page->exists()) {
+            $suffix = " - ";
+            $suffix .= _t(
+                 __CLASS__ . ".ON_PAGE_TITLE",
+                 "on {pageType} '{pageTitle}'",
+                 [
+                     'pageType' => strtolower($page->i18n_singular_name()),
+                     'pageTitle' => $page->Title
+                 ]
+            );
+        }
+        return "{$title} (#{$this->ID}){$suffix}";
     }
 
     public function getCMSFields()

--- a/src/Models/GalleryVideo.php
+++ b/src/Models/GalleryVideo.php
@@ -110,10 +110,15 @@ class GalleryVideo extends DataObject {
                 'Root.Main',
                 DropdownField::create(
                     'ParentID',
-                    _t(__CLASS__ . '.GALLERY', 'Gallery'),
+                    _t(__CLASS__ . '.CHOOSE_A_GALLERY', 'Choose a video gallery'),
                     ElementVideoGallery::get()
                         ->sort('Title ASC')
                         ->map("ID","DropdownTitle")
+                )->setDescription(
+                    _t(
+                        __CLASS__ . '.CHOOSE_A_GALLERY_DESCRIPTION',
+                        'Changing the gallery will move the video to that gallery'
+                    ),
                 )->setEmptyString(''),
                 'Video'
             );

--- a/src/Models/GalleryVideo.php
+++ b/src/Models/GalleryVideo.php
@@ -103,7 +103,7 @@ class GalleryVideo extends DataObject {
     public function getCMSFields() {
         $fields = parent::getCMSFields();
 
-        $fields->removeByName(['LinkTargetID', 'Sort']);
+        $fields->removeByName(['ParentID', 'LinkTargetID', 'Sort']);
 
         if(Controller::curr() instanceof VideoAdmin) {
             $fields->addFieldToTab(

--- a/src/Models/GalleryVideo.php
+++ b/src/Models/GalleryVideo.php
@@ -1,10 +1,12 @@
 <?php
 namespace NSWDPC\Elemental\Models\FeaturedVideo;
 
+use SilverStripe\Control\Controller;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\AssetAdmin\Forms\UploadField;
 use SilverStripe\Assets\Image;
+use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\Forms\OptionsetField;
@@ -51,6 +53,7 @@ class GalleryVideo extends DataObject {
 
     private static $summary_fields = [
         'Image.CMSThumbnail' => 'Image',
+        'Parent.DropdownTitle' => 'Gallery',
         'Title' => 'Title',
         'Video' => 'Video Id',
         'Provider' => 'Provider'
@@ -100,7 +103,21 @@ class GalleryVideo extends DataObject {
     public function getCMSFields() {
         $fields = parent::getCMSFields();
 
-        $fields->removeByName(['LinkTargetID', 'ParentID', 'Sort']);
+        $fields->removeByName(['LinkTargetID', 'Sort']);
+
+        if(Controller::curr() instanceof VideoAdmin) {
+            $fields->addFieldToTab(
+                'Root.Main',
+                DropdownField::create(
+                    'ParentID',
+                    _t(__CLASS__ . '.GALLERY', 'Gallery'),
+                    ElementVideoGallery::get()
+                        ->sort('Title ASC')
+                        ->map("ID","DropdownTitle")
+                )->setEmptyString(''),
+                'Video'
+            );
+        }
 
         $fields->addFieldsToTab(
             'Root.Main', [


### PR DESCRIPTION
## Changes

+ Add a model admin to list GalleryVideo records
+ Display the parent video gallery in a dropdown when viewing the gallery in the model admin
+ Provide some context for the gallery element  by showing the 'owner page' if one exists

See: https://github.com/nswdpc/silverstripe-elemental-feature-video/issues/1#issue-804065641