### PR TITLE
Player + Video provider options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ This module provides two content elements for us in an elemental area
 
 ## Features
 
-+ Vimeo and YouTube support, you can extend the elements to provide for other video sources
++ Vimeo, YouTube & YouTube Privacy Enhanced Mode support
++ Sensible defaults for embedded videos
++ Your developer can extend the abstract provider to enable other video sources
 + Basic templates, override these in your own project
 + Transcript, description, link fields
 + Image thumbnails for video placeholders

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,12 @@
             "role": "Developer"
         }
     ],
+    "autoload": {
+        "psr-4": {
+            "NSWDPC\\Elemental\\Models\\FeaturedVideo\\": "src/",
+            "NSWDPC\\Elemental\\Models\\FeaturedVideo\\Tests\\": "tests/"
+        }
+    },
     "require": {
         "symbiote/silverstripe-gridfieldextensions" : "^3",
         "dnadesign/silverstripe-elemental": "^4.3.0",

--- a/src/Models/Elements/ElementVideoGallery.php
+++ b/src/Models/Elements/ElementVideoGallery.php
@@ -10,6 +10,7 @@ use SilverStripe\Forms\TextareaField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 
@@ -35,17 +36,34 @@ class ElementVideoGallery extends ElementContent {
         return _t(__CLASS__ . '.BlockType', 'Video gallery');
     }
 
+    /**
+     * @var array
+     */
     private static $db = [
-        'GalleryStyle' => 'Varchar'
+        'GalleryStyle' => 'Varchar',
+        'VideoHeight' => 'Int'
     ];
 
+    /**
+     * @var array
+     */
     private static $has_many = [
         'Videos' => GalleryVideo::class,
     ];
 
+    /**
+     * @var array
+     */
     private static $owns = [
         'Videos'
     ];
+
+    /**
+     * Save a default height based on the Gallery Video constant
+     */
+    public static function getDefaultHeight() : int {
+        return GalleryVideo::DEFAULT_HEIGHT;
+    }
 
     /**
      * Return a title for a dropdown to assist in identifying this gallery
@@ -90,8 +108,16 @@ class ElementVideoGallery extends ElementContent {
         );
         $config->addComponent(GridFieldOrderableRows::create());
 
+        $heightField = NumericField::create(
+            'VideoHeight',
+            _t(__CLASS__ . ".VIDEO_HEIGHT", "Apply a height to all videos in this gallery (pixels)")
+        );
+        if(!$this->exists()) {
+            $heightField = $heightField->setValue( self::getDefaultHeight() );
+        }
         $fields->addFieldsToTab(
             'Root.Settings', [
+                $heightField,
                 DropdownField::create(
                     "GalleryStyle",
                     _t(__CLASS__ . ".STYLE", "Gallery style"),
@@ -102,7 +128,6 @@ class ElementVideoGallery extends ElementContent {
                 )
             ]
         );
-
         return $fields;
     }
 

--- a/src/Models/GalleryVideo.php
+++ b/src/Models/GalleryVideo.php
@@ -10,10 +10,13 @@ use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\Forms\OptionsetField;
+use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use gorriecoe\Link\Models\Link;
 use NSWDPC\InlineLinker\InlineLinkCompositeField;
 use NSWDPC\Elemental\Models\FeaturedVideo\ElementVideoGallery;
+use SilverStripe\View\Requirements;
+use SilverStripe\ORM\ValidationException;
 
 /**
  * Images in an ElementVideo
@@ -58,6 +61,11 @@ class GalleryVideo extends DataObject {
     /**
      * @var string
      */
+    private static $allow_attribute = 'autoplay; fullscreen; picture-in-picture';
+
+    /**
+     * @var string
+     */
     const PROVIDER_VIMEO = 'vimeo';
 
     /**
@@ -91,10 +99,10 @@ class GalleryVideo extends DataObject {
      */
     private static $summary_fields = [
         'Image.CMSThumbnail' => 'Image',
-        'Parent.DropdownTitle' => 'Gallery',
         'Title' => 'Title',
         'Video' => 'Video Id',
-        'Provider' => 'Provider'
+        'Provider' => 'Provider',
+        'Parent.DropdownTitle' => 'Gallery'
     ];
 
     /**
@@ -122,6 +130,17 @@ class GalleryVideo extends DataObject {
     ];
 
     /**
+     * Default height of video, if none specified
+     * @var int
+     */
+    const DEFAULT_HEIGHT = 360;
+
+    /**
+     * @var int
+     */
+    protected $videoHeight = 0;
+
+    /**
      * Allowed file types for the video image
      */
     public function getAllowedFileTypes() : array {
@@ -134,15 +153,13 @@ class GalleryVideo extends DataObject {
     }
 
     /**
-     * Allowed file types for the video image
+     * Get available video providers
      */
     public function getVideoProviders() : array {
-        $list = [
-            self::PROVIDER_VIMEO => _t(__CLASS__ . '.PROVIDER_VIMEO', 'Vimeo'),
-            self::PROVIDER_YOUTUBE => _t(__CLASS__ . '.PROVIDER_YOUTUBE', 'YouTube'),
-        ];
-        $this->extend('updateVideoProviders', $list);
-        return $list;
+        $providers = VideoProvider::getProviderSelections();
+        // @deprecated updateVideoProviders - this will be removed in v1
+        $this->extend('updateVideoProviders', $providers);
+        return $providers;
     }
 
     /**
@@ -154,6 +171,18 @@ class GalleryVideo extends DataObject {
             $folder_name = "videos";
         }
         return $folder_name;
+    }
+
+    public function onBeforeWrite() {
+        parent::onBeforeWrite();
+        if(preg_match("/^http(s)?:\/\//", $this->Video)) {
+            throw new ValidationException(
+                _t(
+                    __CLASS__ . ".VIDEO_ID_NOT_URL",
+                    "Please use the video id from the embed URL, not the URL itself"
+                )
+            );
+        }
     }
 
     /**
@@ -184,19 +213,41 @@ class GalleryVideo extends DataObject {
             );
         }
 
+
+        $description = '';
+        if($this->Video && $this->Provider) {
+            $embedURL = $this->EmbedURL();
+            if($embedURL) {
+                $description = _t(
+                    __CLASS__ . ".VIDEO_EMBED_URL",
+                    "The following URL will be used: <code>{embedURL}</code>",
+                    [
+                        'embedURL' => $embedURL
+                    ]
+                );
+            }
+        }
+
         $fields->addFieldsToTab(
             'Root.Main', [
                 OptionsetField::create(
                     'Provider',
-                    _t(__CLASS__ . '.PROVIDER', 'Video provider'),
+                    _t(__CLASS__ . '.PROVIDER', 'Choose a video source'),
                     $this->getVideoProviders()
                 ),
                 TextField::create(
                     'Video',
                     _t(
-                        __CLASS__ . 'VIDEO', 'Video ID'
+                        __CLASS__ . 'VIDEO_ID_VALUE', 'Enter the video identifier/code. The embed URL for the video will be automatically created based on this value.'
                     )
-                )->setDescription("Use the video ID only, e.g.; https://www.youtube.com/watch?v=<strong>oJL-lCzEXgI</strong>"),
+                )->setRightTitle(
+                    _t(
+                        __CLASS__ . ".VIDEO_EMBED_DESCRIPTION",
+                        "Example: oJL-lCzEXgI from  https://www.youtube.com/embed/oJL-lCzEXgI"
+                    )
+                )->setDescription(
+                    $description
+                ),
                 TextareaField::create(
                     'Description',
                     _t(
@@ -246,6 +297,75 @@ class GalleryVideo extends DataObject {
      */
     public function getMultiRecordEditingTitle() {
         return $this->singular_name();
+    }
+
+    /**
+     * Allow some control of the video height eg. from a gallery parent
+     */
+    public function setVideoHeight(int $height) : self {
+        $this->videoHeight = $height;
+        return $this;
+    }
+
+    /**
+     * Get specified height. Some providers allow a height to be set via URL arg
+     */
+    public function getVideoHeight() :int {
+        $parent = $this->Parent();
+        if($parent && $parent->VideoHeight > 0) {
+            return $parent->VideoHeight;
+        } elseif($this->videoHeight > 0) {
+            return $this->videoHeight;
+        } else {
+            return self::DEFAULT_HEIGHT;
+        }
+    }
+
+    /**
+     *
+     */
+    protected function applyRequirements() {
+        $height = $this->getVideoHeight();
+        Requirements::customCSS(
+<<<CSS
+.embed.video {
+    position: relative;
+    overflow: hidden;
+    padding-top: 56.25%;/* 16:9 */
+    height : {$height}px;
+}
+
+.embed.video > iframe {
+    border: 0;
+    height: 100% !important;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+}
+CSS,
+            'galleryVideoEmbedCSS'
+        );
+    }
+
+    /**
+     * Return the URL to embed the video in an <iframe>
+     */
+    public function EmbedURL() : string {
+        $this->applyRequirements();
+        $provider = VideoProvider::getProvider( $this->Provider );
+        if($provider) {
+            return $provider->getEmbedURL( $this->Video, [], $this->getVideoHeight() );
+        } else {
+            return "";
+        }
+    }
+
+    /**
+     * Return allow="" value for <iframe>
+     */
+    public function AllowAttribute() : string {
+        return $this->config()->get('allow_attribute');
     }
 
     /**

--- a/src/Models/GalleryVideo.php
+++ b/src/Models/GalleryVideo.php
@@ -74,6 +74,11 @@ class GalleryVideo extends DataObject {
     const PROVIDER_YOUTUBE = 'youtube';
 
     /**
+     * @var string
+     */
+    const PROVIDER_YOUTUBE_NOCOOKIE = 'youtube-nocookie';
+
+    /**
      * @var array
      */
     private static $db = [

--- a/src/Models/GalleryVideo.php
+++ b/src/Models/GalleryVideo.php
@@ -20,22 +20,54 @@ use NSWDPC\Elemental\Models\FeaturedVideo\ElementVideoGallery;
  */
 class GalleryVideo extends DataObject {
 
+    /**
+     * @var string
+     */
     private static $table_name = 'GalleryVideo';
 
+    /**
+     * @var string
+     */
     private static $versioned_gridfield_extensions = true;
 
+    /**
+     * @var string
+     */
     private static $singular_name = 'Video';
+
+    /**
+     * @var string
+     */
     private static $plural_name = 'Videos';
 
+    /**
+     * @var string
+     */
     private static $default_sort = 'Sort';
 
+    /**
+     * @var array
+     */
     private static $allowed_file_types = ["jpg","jpeg","gif","png","webp"];
 
+    /**
+     * @var string
+     */
     private static $folder_name = 'videos';
 
+    /**
+     * @var string
+     */
     const PROVIDER_VIMEO = 'vimeo';
+
+    /**
+     * @var string
+     */
     const PROVIDER_YOUTUBE = 'youtube';
 
+    /**
+     * @var array
+     */
     private static $db = [
         'Title' => 'Varchar(255)',
         'Video' => 'Varchar(255)',
@@ -45,12 +77,18 @@ class GalleryVideo extends DataObject {
         'Transcript' => 'HTMLText',
     ];
 
+    /**
+     * @var array
+     */
     private static $has_one = [
         'Image' => Image::class,
         'Parent' => ElementVideoGallery::class,
         'LinkTarget' => Link::class
     ];
 
+    /**
+     * @var array
+     */
     private static $summary_fields = [
         'Image.CMSThumbnail' => 'Image',
         'Parent.DropdownTitle' => 'Gallery',
@@ -59,6 +97,9 @@ class GalleryVideo extends DataObject {
         'Provider' => 'Provider'
     ];
 
+    /**
+     * @var array
+     */
     private static $searchable_fields = [
         'Title' => 'PartialMatchFilter',
         'Video' => 'PartialMatchFilter',
@@ -66,15 +107,24 @@ class GalleryVideo extends DataObject {
         'Description' => 'PartialMatchFilter'
     ];
 
+    /**
+     * @var array
+     */
     private static $owns = [
         'Image'
     ];
 
+    /**
+     * @var array
+     */
     private static $extensions = [
         Versioned::class
     ];
 
-    public function getAllowedFileTypes() {
+    /**
+     * Allowed file types for the video image
+     */
+    public function getAllowedFileTypes() : array {
         $types = $this->config()->get('allowed_file_types');
         if(empty($types)) {
             $types = ["jpg","jpeg","gif","png","webp"];
@@ -83,7 +133,10 @@ class GalleryVideo extends DataObject {
         return $types;
     }
 
-    public function getVideoProviders() {
+    /**
+     * Allowed file types for the video image
+     */
+    public function getVideoProviders() : array {
         $list = [
             self::PROVIDER_VIMEO => _t(__CLASS__ . '.PROVIDER_VIMEO', 'Vimeo'),
             self::PROVIDER_YOUTUBE => _t(__CLASS__ . '.PROVIDER_YOUTUBE', 'YouTube'),
@@ -92,7 +145,10 @@ class GalleryVideo extends DataObject {
         return $list;
     }
 
-    public function getFolderName() {
+    /**
+     * Folder name for uploaded thumbnails
+     */
+    public function getFolderName() : string {
         $folder_name = $this->config()->get('folder_name');
         if(!$folder_name) {
             $folder_name = "videos";
@@ -100,6 +156,10 @@ class GalleryVideo extends DataObject {
         return $folder_name;
     }
 
+    /**
+     * CMS fields for video management
+     *
+     */
     public function getCMSFields() {
         $fields = parent::getCMSFields();
 
@@ -180,10 +240,17 @@ class GalleryVideo extends DataObject {
         return $fields;
     }
 
+    /**
+     * Title for symbiote/silverstripe-multirecordfield
+     * @return string
+     */
     public function getMultiRecordEditingTitle() {
         return $this->singular_name();
     }
 
+    /**
+     * Render this record into a template
+     */
     public function forTemplate() {
         return $this->renderWith([$this->class, __CLASS__]);
     }

--- a/src/Models/VideoProvider.php
+++ b/src/Models/VideoProvider.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace NSWDPC\Elemental\Models\FeaturedVideo;
+
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Core\Injector\Injector;
+
+/**
+ * Abstract class for all video providers
+ * @author James
+ */
+abstract class VideoProvider {
+
+    use Configurable;
+
+    use Injectable;
+
+    /**
+     * Default to https://
+     */
+    public function getProtocol() : string {
+        return "https://";
+    }
+
+    abstract public static function getProviderCode() : string;
+
+    abstract public static function getProviderDescription() : string;
+
+    abstract public function getHost() : string;
+
+    abstract public function getPath(string $videoId = '') : string;
+
+    abstract public function getQueryArguments() : array;
+
+    abstract public function getEmbedURL(string $videoId, array $customQueryArgs, int $videoHeight) : string;
+
+    /**
+     * Return the available providers, subclasses of this class
+     */
+    public static function getProviders() : array {
+        $providers = [];
+        $children = ClassInfo::subclassesFor( self::class, false );
+        return $children;
+    }
+
+    /**
+     * Return the VideoProvider class for the given code
+     */
+    public static function getProvider($code) : ?VideoProvider {
+        $providers = self::getProviders();
+        foreach($providers as $childClass => $providerClass) {
+            if($providerClass::getProviderCode() == $code) {
+                return Injector::inst()->create( $providerClass );
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Return an array allowing selection of a provider from a field
+     */
+    public static function getProviderSelections() : array {
+        $selection = [];
+        $providers = self::getProviders();
+        foreach($providers as $childClass => $providerClass) {
+            $inst = Injector::inst()->create( $providerClass );
+            $selection[ $inst->getProviderCode() ] = $inst->getProviderDescription();
+        }
+        return $selection;
+    }
+
+}

--- a/src/Models/Vimeo.php
+++ b/src/Models/Vimeo.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace NSWDPC\Elemental\Models\FeaturedVideo;
+
+/**
+ * Vimeo provider, based on https://vimeo.zendesk.com/hc/en-us/articles/360001494447-Player-parameters-overview
+ * @author James
+ */
+class Vimeo extends VideoProvider {
+
+    /**
+     * Return ident code for this video, used to load an instance of this class
+     */
+    public static function getProviderCode() : string {
+        return GalleryVideo::PROVIDER_VIMEO;
+    }
+
+    /**
+     * Description for assistance in identifying the provider
+     */
+    public static function getProviderDescription() : string {
+        return _t(
+            GalleryVideo::class . ".VIMEO_PROVIDER_DESCRIPTION",
+            "Vimeo"
+        );
+    }
+
+    /**
+     * Return Vimeo host for URL
+     */
+    public function getHost() : string {
+        return "player.vimeo.com";
+    }
+
+    /**
+     * Return Vimeo path for URL
+     */
+     public function getPath($videoId = '') : string {
+         if($videoId) {
+             return "/video/{$videoId}/";
+         } else {
+             return "";
+         }
+     }
+
+    /**
+     * Return Vimeo default query arguments for URL
+     * See: https://vimeo.zendesk.com/hc/en-us/articles/360001494447-Player-parameters-overview
+     */
+    public function getQueryArguments() : array {
+        return [
+            "autoplay" => 0,
+            "color" => "ffffff",
+            "title" => 0,
+            "byline" => 0,
+            "portrait" => 1,
+            "dnt" => 1,
+            "transparent" => 0
+        ];
+    }
+
+    /**
+     * Return Embed URL for the video
+     */
+    public function getEmbedURL(string $videoID, array $customQueryArgs, int $videoHeight) : string {
+        if($videoHeight > 0) {
+            $customQueryArgs['height'] = $videoHeight;
+        }
+        $query = array_merge($this->getQueryArguments(), $customQueryArgs);
+        $queryString = http_build_query($query);
+        return $this->getProtocol()
+            . $this->getHost()
+            . $this->getPath($videoID)
+            . ($queryString ? "?{$queryString}" : "");
+    }
+}

--- a/src/Models/YouTube.php
+++ b/src/Models/YouTube.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace NSWDPC\Elemental\Models\FeaturedVideo;
+
+/**
+ * YouTube provider, based on https://developers.google.com/youtube/player_parameters
+ * @author James
+ */
+class YouTube extends VideoProvider {
+
+    /**
+     * @var bool
+     */
+    private static $use_nocookie = false;
+
+    /**
+     * Return ident code for this video, used to load an instance of this class
+     */
+    public static function getProviderCode() : string {
+        return GalleryVideo::PROVIDER_YOUTUBE;
+    }
+
+    /**
+     * Description for assistance in identifying the provider
+     */
+    public static function getProviderDescription() : string {
+        return _t(
+            GalleryVideo::class . ".YOUTUBE_PROVIDER_DESCRIPTION",
+            "YouTube"
+        );
+    }
+
+    /**
+     * Return YouTube host for URL
+     */
+    public function getHost() : string {
+        if($this->config()->get('use_nocookie')) {
+            return "youtube-nocookie.com";
+        } else {
+            return "www.youtube.com";
+        }
+    }
+
+    /**
+     * Return YouTube path for URL
+     */
+     public function getPath($videoId = '') : string {
+         if($videoId) {
+             return "/embed/{$videoId}/";
+         } else {
+             return "";
+         }
+     }
+
+    /**
+     * Return YouTube default query arguments for URL
+     * Provide some sensible defaults. You can override these in getEmbedURL
+     */
+    public function getQueryArguments() : array {
+        return [
+            "autoplay" => 0,
+            "modestbranding" => 0,
+            "fs" => 1,
+            "rel" => 0 // show related videos from the same channel
+        ];
+    }
+
+    /**
+     * Return Embed URL for the video
+     */
+    public function getEmbedURL(string $videoID, array $customQueryArgs, int $videoHeight) : string {
+        $query = array_merge($this->getQueryArguments(), $customQueryArgs);
+        $queryString = http_build_query($query);
+        return $this->getProtocol()
+            . $this->getHost()
+            . $this->getPath($videoID)
+            . ($queryString ? "?{$queryString}" : "");
+    }
+}

--- a/src/Models/YouTube.php
+++ b/src/Models/YouTube.php
@@ -9,11 +9,6 @@ namespace NSWDPC\Elemental\Models\FeaturedVideo;
 class YouTube extends VideoProvider {
 
     /**
-     * @var bool
-     */
-    private static $use_nocookie = false;
-
-    /**
      * Return ident code for this video, used to load an instance of this class
      */
     public static function getProviderCode() : string {
@@ -34,11 +29,7 @@ class YouTube extends VideoProvider {
      * Return YouTube host for URL
      */
     public function getHost() : string {
-        if($this->config()->get('use_nocookie')) {
-            return "youtube-nocookie.com";
-        } else {
-            return "www.youtube.com";
-        }
+        return "www.youtube.com";
     }
 
     /**

--- a/src/Models/YouTubeNoCookie.php
+++ b/src/Models/YouTubeNoCookie.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace NSWDPC\Elemental\Models\FeaturedVideo;
+
+/**
+ * YouTube provider using www,youtube-nocookie.com as the host
+ * @author James
+ */
+class YouTubeNoCookie extends YouTube {
+
+    /**
+     * @inheritdoc
+     */
+    public static function getProviderCode() : string {
+        return GalleryVideo::PROVIDER_YOUTUBE_NOCOOKIE;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getProviderDescription() : string {
+        return _t(
+            GalleryVideo::class . ".YOUTUBE_NOCOOKIE_PROVIDER_DESCRIPTION",
+            "YouTube (privacy enhanced mode)"
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getHost() : string {
+        return "www.youtube-nocookie.com";
+    }
+}

--- a/templates/NSWDPC/Elemental/Models/FeaturedVideo/GalleryVideo.ss
+++ b/templates/NSWDPC/Elemental/Models/FeaturedVideo/GalleryVideo.ss
@@ -1,0 +1,29 @@
+<figure>
+
+    <div class="embed video">
+    <% if $EmbedURL %>
+        <% include NSWDPC/Elemental/Models/FeaturedVideo/Iframe EmbedURL=$EmbedURL, Anchor=$Parent.Anchor, ID=$ID, AllowAttribute=$AllowAttribute %>
+    <% else %>
+        <!-- no URL for this video was found -->
+    <% end_if %>
+    </div>
+
+    <% if $Description || $LinkTarget %>
+    <figcaption>
+        <% if $Description %><p>{$Description.XML}</p><% end_if %>
+        <% if $LinkTarget %>
+            <p><a href="{$LinkTarget.LinkURL}">{$LinkTarget.Title}</a></p>
+        <% end_if %>
+    </figcaption>
+    <% end_if %>
+
+    <% if $Transcript %>
+    <div class="transcript">
+        <h4>Transcript</h4>
+        <div class="content">
+            {$Transcript}
+        </div>
+    </div>
+    <% end_if %>
+
+</figure>

--- a/templates/NSWDPC/Elemental/Models/FeaturedVideo/Includes/Iframe.ss
+++ b/templates/NSWDPC/Elemental/Models/FeaturedVideo/Includes/Iframe.ss
@@ -1,0 +1,1 @@
+<iframe loading="lazy" id="video-{$ID}-{$Anchor}" src="{$EmbedURL}" allow="{$AllowAttribute}" allowfullscreen></iframe>

--- a/tests/GalleryVideoTest.php
+++ b/tests/GalleryVideoTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace NSWDPC\Elemental\Models\FeaturedVideo\Tests;
+
+use NSWDPC\Elemental\Models\FeaturedVideo\GalleryVideo;
+use NSWDPC\Elemental\Models\FeaturedVideo\YouTube;
+use NSWDPC\Elemental\Models\FeaturedVideo\Vimeo;
+use NSWDPC\Elemental\Models\FeaturedVideo\YouTubeNoCookie;
+use NSWDPC\Elemental\Models\FeaturedVideo\VideoProvider;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ValidationException;
+
+/**
+ * Provide tests for video embed
+ */
+class GalleryVideoTest extends SapphireTest {
+
+    public function testValidationWrite() {
+        try {
+            $video = GalleryVideo::create();
+            $video->Provider = GalleryVideo::PROVIDER_YOUTUBE;
+            // provide a URL as a video embed code, fail on validation
+            $video->Video = "https://www.youtube.com/embed/123456/";
+            $video->Title = "YouTube Test";
+            $video->Description = "YouTube Description";
+            $video->Transcript = "<p>YouTube Transcript</p>";
+            $video->write();
+            $this->assertFalse($video->IsInDB());
+        } catch (ValidationException $e) {
+            $this->assertNotEmpty($e->getMessage());
+        }
+    }
+
+    public function testVideoHeight() {
+
+        $video = GalleryVideo::create();
+        $video->Provider = GalleryVideo::PROVIDER_YOUTUBE;
+        $video->Video = "testyoutube";
+        $video->Title = "YouTube Test";
+        $video->Description = "YouTube Description";
+        $video->Transcript = "<p>YouTube Transcript</p>";
+        $video->write();
+
+        $height = 412;
+
+        $video->setVideoHeight($height);
+
+        $this->assertEquals($height, $video->getVideoHeight());
+    }
+
+    public function testYouTube() {
+
+        $video = GalleryVideo::create();
+        $video->Provider = GalleryVideo::PROVIDER_YOUTUBE;
+        $video->Video = "testyoutube";
+        $video->Title = "YouTube Test";
+        $video->Description = "YouTube Description";
+        $video->Transcript = "<p>YouTube Transcript</p>";
+        $video->write();
+
+        $provider = VideoProvider::getProvider( $video->Provider );
+
+        $this->assertInstanceOf( YouTube::class, $provider );
+
+        $url = $video->EmbedURL();
+
+        $this->assertNotEmpty($url, "URL empty");
+
+        $parts = parse_url($url);
+
+        $this->assertEquals("www.youtube.com", $parts['host']);
+        $this->assertEquals("https", $parts['scheme']);
+        $this->assertEquals("/embed/testyoutube/", $parts['path']);
+
+        $this->assertNotEmpty($parts['query']);
+
+        parse_str($parts['query'], $query);
+
+        $expected = [
+            "autoplay" => 0,
+            "modestbranding" => 0,
+            "fs" => 1,
+            "rel" => 0
+        ];
+
+        asort($query);
+        asort($expected);
+
+        $this->assertEquals( $expected, $query );
+
+    }
+
+    public function testYouTubeNoCookie() {
+
+        $video = GalleryVideo::create();
+        $video->Provider = GalleryVideo::PROVIDER_YOUTUBE_NOCOOKIE;
+        $video->Video = "testyoutube-nocookie";
+        $video->Title = "YouTube NoCookie Test";
+        $video->Description = "YouTube NoCookie Description";
+        $video->Transcript = "<p>YouTube NoCookie Transcript</p>";
+        $video->write();
+
+        $provider = VideoProvider::getProvider( $video->Provider );
+
+        $this->assertInstanceOf( YouTubeNoCookie::class, $provider );
+
+        $url = $video->EmbedURL();
+
+        $this->assertNotEmpty($url, "URL empty");
+
+        $parts = parse_url($url);
+
+        $this->assertEquals("www.youtube-nocookie.com", $parts['host']);
+        $this->assertEquals("https", $parts['scheme']);
+        $this->assertEquals("/embed/testyoutube-nocookie/", $parts['path']);
+
+        $this->assertNotEmpty($parts['query']);
+
+        parse_str($parts['query'], $query);
+
+        $expected = [
+            "autoplay" => 0,
+            "modestbranding" => 0,
+            "fs" => 1,
+            "rel" => 0
+        ];
+
+        asort($query);
+        asort($expected);
+
+        $this->assertEquals( $expected, $query );
+
+    }
+
+    public function testVimeo() {
+
+        $video = GalleryVideo::create();
+        $video->Provider = GalleryVideo::PROVIDER_VIMEO;
+        $video->Video = "testvimeo";
+        $video->Title = "Vimeo Test";
+        $video->Description = "Vimeo Description";
+        $video->Transcript = "<p>Vimeo Transcript</p>";
+        $video->write();
+
+        $provider = VideoProvider::getProvider( $video->Provider );
+
+        $this->assertInstanceOf( Vimeo::class, $provider );
+
+        $url = $video->EmbedURL();
+
+        $this->assertNotEmpty($url, "URL empty");
+
+        $parts = parse_url($url);
+
+        $this->assertEquals("player.vimeo.com", $parts['host']);
+        $this->assertEquals("https", $parts['scheme']);
+        $this->assertEquals("/video/testvimeo/", $parts['path']);
+
+        $this->assertNotEmpty($parts['query']);
+
+        parse_str($parts['query'], $query);
+
+        $expected = [
+            "autoplay" => 0,
+            "color" => "ffffff",
+            "title" => 0,
+            "byline" => 0,
+            "portrait" => 1,
+            "dnt" => 1,
+            "transparent" => 0,
+            "height" => $video->getVideoHeight()
+        ];
+
+        asort($query);
+        asort($expected);
+
+        $this->assertEquals( $expected, $query );
+
+    }
+}


### PR DESCRIPTION
## Changes

Ref: #5 

+ Add video provider classes to support configurable players
+ Provide EmbedURL method for templates to apply an iframe src attribute
+ Provide AllowAttribute method for templates to apply an iframe allow attribute
+ NEW: YouTubeNoCookie support (Privacy Enhanced Mode)
+ Add sensible YouTube player parameters, notable rel=0 to only allow related videos from the same channel to appear
+ Update documentation
+ Add tests to suit

