### PR TITLE
Minimum silverstripe support changes + embed/embed handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         }
     },
     "require": {
+        "embed/embed": "^3.4",
         "symbiote/silverstripe-gridfieldextensions" : "^3",
         "dnadesign/silverstripe-elemental": "^4.3.0",
         "gorriecoe/silverstripe-linkfield" : "^1",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         }
     },
     "require": {
+        "silverstripe/framework": "^4.10.0",
         "symbiote/silverstripe-gridfieldextensions" : "^3",
         "dnadesign/silverstripe-elemental": "^4.3.0",
         "gorriecoe/silverstripe-linkfield" : "^1",
@@ -38,6 +39,6 @@
         "nswdpc/silverstripe-inline-linker": "dev-master"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^9.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "silverstripe/framework": "^4.10.0",
-        "embed/embed": "^4.4",
+        "embed/embed": "^3.4 | ^4.4",
         "symbiote/silverstripe-gridfieldextensions" : "^3",
         "dnadesign/silverstripe-elemental": "^4.3.0",
         "gorriecoe/silverstripe-linkfield" : "^1",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "silverstripe/framework": "^4.10.0",
-        "embed/embed": "^3.4",
+        "embed/embed": "^4.4",
         "symbiote/silverstripe-gridfieldextensions" : "^3",
         "dnadesign/silverstripe-elemental": "^4.3.0",
         "gorriecoe/silverstripe-linkfield" : "^1",

--- a/src/Models/VideoProvider.php
+++ b/src/Models/VideoProvider.php
@@ -73,4 +73,11 @@ abstract class VideoProvider {
         return $selection;
     }
 
+    /**
+     * Return the provider code for this video from an instance of this provider
+     */
+    public function getVideoProviderCode() : string {
+        return static::getProviderCode();
+    }
+
 }

--- a/src/Models/YouTube.php
+++ b/src/Models/YouTube.php
@@ -2,6 +2,8 @@
 
 namespace NSWDPC\Elemental\Models\FeaturedVideo;
 
+use Silverstripe\Control\Director;
+
 /**
  * YouTube provider, based on https://developers.google.com/youtube/player_parameters
  * @author James
@@ -49,6 +51,8 @@ class YouTube extends VideoProvider {
      */
     public function getQueryArguments() : array {
         return [
+            "enablejsapi" => 1,
+            "origin" => Director::protocolAndHost(),
             "autoplay" => 0,
             "modestbranding" => 0,
             "fs" => 1,

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -3,6 +3,7 @@
 namespace NSWDPC\Elemental\Models\FeaturedVideo;
 
 use Embed\Embed;
+use Silverstripe\Core\Convert;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\View\Requirements;
 
@@ -168,6 +169,22 @@ CSS,
         $info = $this->getOEmbedData();
         $value = isset($info->image) ? $info->image : null;
         return $value;
+    }
+
+    /**
+     * Return current video's provider code, determined by the Provider value
+     * Allows templates to use $VideoProviderCode in a data attribute
+     */
+    public function getVideoProviderCode() : ?string {
+        $inst = VideoProvider::getProvider( $this->Provider );
+        if($inst) {
+            /**
+             * @var VideoProvider
+             */
+            return $inst->getVideoProviderCode();
+        } else {
+            return null;
+        }
     }
 
 }

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -166,8 +166,15 @@ CSS,
      * Return OEmbed image value
      */
     public function getOEmbedImage() : ?string {
-        $info = $this->getOEmbedData();
-        $value = isset($info->image) ? $info->image : null;
+        $value = null;
+        try {
+            $info = $this->getOEmbedData();
+            if($image = $info->image) {
+                $value = $info->image->__toString();
+            }
+        } catch (\Exception $e) {
+            // oembed failure to retrieve property
+        }
         return $value;
     }
 

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -3,7 +3,6 @@
 namespace NSWDPC\Elemental\Models\FeaturedVideo;
 
 use Embed\Embed;
-use Embed\Extractor;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\View\Requirements;
 
@@ -139,14 +138,21 @@ CSS,
     /**
      * Return OEmbed data from embed/embed
      * @param bool $force true = force request to be made
-     * @return Extractor|null
+     * @return mixed
      */
-    public function getOEmbedData($force = false) : ?Extractor {
+    public function getOEmbedData($force = false) {
         try {
             if(is_null($this->oEmbedData) || $force) {
                 $watchURL = $this->WatchURL();
-                $embed = new Embed();
-                $this->oEmbedData = $embed->get( $watchURL );
+                $reflector = new \ReflectionClass(Embed::class);
+                if($reflector->isAbstract()) {
+                    // embed/embed v3
+                    $this->oEmbedData = Embed::create( $watchURL );
+                } else {
+                    // embed/embed v4
+                    $embed = new Embed();
+                    $this->oEmbedData = $embed->get( $watchURL );
+                }
             }
         } catch (\Exception $e) {
             // some error occurred

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -3,6 +3,7 @@
 namespace NSWDPC\Elemental\Models\FeaturedVideo;
 
 use Embed\Embed;
+use Embed\Extractor;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\View\Requirements;
 
@@ -138,14 +139,14 @@ CSS,
     /**
      * Return OEmbed data from embed/embed
      * @param bool $force true = force request to be made
-     * @return mixed
+     * @return Extractor|null
      */
-    public function getOEmbedData($force = false) {
+    public function getOEmbedData($force = false) : ?Extractor {
         try {
             if(is_null($this->oEmbedData) || $force) {
                 $watchURL = $this->WatchURL();
-                $reflector = new \ReflectionClass(Embed::class);
-                $this->oEmbedData = Embed::create( $watchURL );
+                $embed = new Embed();
+                $this->oEmbedData = $embed->get( $watchURL );
             }
         } catch (\Exception $e) {
             // some error occurred

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -2,6 +2,7 @@
 
 namespace NSWDPC\Elemental\Models\FeaturedVideo;
 
+use Embed\Embed;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\View\Requirements;
 
@@ -15,6 +16,12 @@ trait VideoFromProvider {
      * @var int
      */
     protected $videoHeight = 0;
+
+
+    /**
+     * @var Extractor|null
+     */
+    protected $oEmbedData = null;
 
     /**
      * Get available video providers
@@ -126,6 +133,34 @@ CSS,
      */
     public function AllowAttribute() : string {
         return '';
+    }
+
+    /**
+     * Return OEmbed data from embed/embed
+     * @param bool $force true = force request to be made
+     * @return mixed
+     */
+    public function getOEmbedData($force = false) {
+        try {
+            if(is_null($this->oEmbedData) || $force) {
+                $watchURL = $this->WatchURL();
+                $reflector = new \ReflectionClass(Embed::class);
+                $this->oEmbedData = Embed::create( $watchURL );
+            }
+        } catch (\Exception $e) {
+            // some error occurred
+            $this->oEmbedData = null;
+        }
+        return $this->oEmbedData;
+    }
+
+    /**
+     * Return OEmbed image value
+     */
+    public function getOEmbedImage() : ?string {
+        $info = $this->getOEmbedData();
+        $value = isset($info->image) ? $info->image : null;
+        return $value;
     }
 
 }

--- a/templates/NSWDPC/Elemental/Models/FeaturedVideo/GalleryVideo.ss
+++ b/templates/NSWDPC/Elemental/Models/FeaturedVideo/GalleryVideo.ss
@@ -1,10 +1,20 @@
 <figure>
 
     <div class="embed video">
-    <% if $EmbedURL %>
+    <% if $UseVideoThumbnail == 1 %>
+        <% if $WatchURL %><a href="{$WatchURL}" rel="noopener"><% end_if %>
+        <% if $VideoThumbnail %>
+        <img src="{$VideoThumbnail}" class="video-thumbnail" referrerpolicy="no-referrer" loading="lazy">
+        <% end_if %>
+        <% if $WatchURL %></a><% end_if %>
+    <% else if $UseVideoThumbnail == 0 %>
+        <% if $WatchURL %><a href="{$WatchURL}" rel="noopener"><% end_if %>
+        {$Image.ScaleWidth(720)
+        <% if $WatchURL %></a><% end_if %>
+    <% else if $EmbedURL %>
         <% include NSWDPC/Elemental/Models/FeaturedVideo/Iframe EmbedURL=$EmbedURL, Anchor=$Parent.Anchor, ID=$ID, AllowAttribute=$AllowAttribute %>
     <% else %>
-        <!-- no URL for this video was found -->
+        <!-- no URL or thumbnail for this video was found -->
     <% end_if %>
     </div>
 

--- a/templates/NSWDPC/Elemental/Models/FeaturedVideo/Includes/Iframe.ss
+++ b/templates/NSWDPC/Elemental/Models/FeaturedVideo/Includes/Iframe.ss
@@ -1,1 +1,1 @@
-<iframe loading="lazy" id="video-{$ID}-{$Anchor}" src="{$EmbedURL}" allow="{$AllowAttribute}" allowfullscreen></iframe>
+<iframe loading="lazy" id="video-{$ID}-{$Anchor}" src="{$EmbedURL}" allow="{$AllowAttribute}"<% if $VideoProviderCode %> data-video-provider="{$VideoProviderCode.XML}"<% end_if %> allowfullscreen></iframe>

--- a/tests/ElementFeaturedVideoTest.php
+++ b/tests/ElementFeaturedVideoTest.php
@@ -7,6 +7,7 @@ use NSWDPC\Elemental\Models\FeaturedVideo\Vimeo;
 use NSWDPC\Elemental\Models\FeaturedVideo\YouTubeNoCookie;
 use NSWDPC\Elemental\Models\FeaturedVideo\VideoProvider;
 use NSWDPC\Elemental\Models\FeaturedVideo\ElementFeaturedVideo;
+use SilverStripe\Control\Director;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\ValidationException;
 
@@ -14,6 +15,8 @@ use SilverStripe\ORM\ValidationException;
  * Provide tests for element featured video
  */
 class ElementFeaturedVideoTest extends SapphireTest {
+
+    protected $usesDatabase =  true;
 
     public function testThumbWidthHeight() {
         $video = ElementFeaturedVideo::create();
@@ -110,7 +113,9 @@ class ElementFeaturedVideoTest extends SapphireTest {
             "autoplay" => 0,
             "modestbranding" => 0,
             "fs" => 1,
-            "rel" => 0
+            "rel" => 0,
+            "enablejsapi" => 1,
+            "origin" => Director::protocolAndHost()
         ];
 
         asort($query);
@@ -152,7 +157,9 @@ class ElementFeaturedVideoTest extends SapphireTest {
             "autoplay" => 0,
             "modestbranding" => 0,
             "fs" => 1,
-            "rel" => 0
+            "rel" => 0,
+            "enablejsapi" => 1,
+            "origin" => Director::protocolAndHost()
         ];
 
         asort($query);

--- a/tests/ElementFeaturedVideoTest.php
+++ b/tests/ElementFeaturedVideoTest.php
@@ -91,6 +91,8 @@ class ElementFeaturedVideoTest extends SapphireTest {
         $video->Transcript = "<p>YouTube Transcript</p>";
         $video->write();
 
+        $this->assertEquals( YouTube::getProviderCode(), $video->getVideoProviderCode() );
+
         $provider = VideoProvider::getProvider( $video->Provider );
 
         $this->assertInstanceOf( YouTube::class, $provider );
@@ -135,6 +137,8 @@ class ElementFeaturedVideoTest extends SapphireTest {
         $video->Transcript = "<p>YouTube NoCookie Transcript</p>";
         $video->write();
 
+        $this->assertEquals( YouTubeNoCookie::getProviderCode(), $video->getVideoProviderCode() );
+
         $provider = VideoProvider::getProvider( $video->Provider );
 
         $this->assertInstanceOf( YouTubeNoCookie::class, $provider );
@@ -178,6 +182,8 @@ class ElementFeaturedVideoTest extends SapphireTest {
         $video->Description = "Vimeo Description";
         $video->Transcript = "<p>Vimeo Transcript</p>";
         $video->write();
+
+        $this->assertEquals( Vimeo::getProviderCode(), $video->getVideoProviderCode() );
 
         $provider = VideoProvider::getProvider( $video->Provider );
 

--- a/tests/ElementVideoTest.php
+++ b/tests/ElementVideoTest.php
@@ -10,6 +10,8 @@ use SilverStripe\Dev\SapphireTest;
  */
 class ElementVideoTest extends SapphireTest {
 
+    protected $usesDatabase =  true;
+
     public function testEmbedHTML() {
 
         $caption = "Caption of the video";

--- a/tests/GalleryVideoTest.php
+++ b/tests/GalleryVideoTest.php
@@ -64,6 +64,8 @@ class GalleryVideoTest extends SapphireTest {
         $video->UseVideoThumbnail = 1;
         $video->write();
 
+        $this->assertEquals( GalleryVideo::PROVIDER_YOUTUBE, $video->getVideoProviderCode() );
+
         $provider = VideoProvider::getProvider( $video->Provider );
 
         $this->assertInstanceOf( YouTube::class, $provider );
@@ -113,6 +115,8 @@ class GalleryVideoTest extends SapphireTest {
         $video->Transcript = "<p>YouTube NoCookie Transcript</p>";
         $video->write();
 
+        $this->assertEquals( GalleryVideo::PROVIDER_YOUTUBE_NOCOOKIE, $video->getVideoProviderCode() );
+
         $provider = VideoProvider::getProvider( $video->Provider );
 
         $this->assertInstanceOf( YouTubeNoCookie::class, $provider );
@@ -161,6 +165,8 @@ class GalleryVideoTest extends SapphireTest {
         $video->Description = "Vimeo Description";
         $video->Transcript = "<p>Vimeo Transcript</p>";
         $video->write();
+
+        $this->assertEquals( GalleryVideo::PROVIDER_VIMEO, $video->getVideoProviderCode() );
 
         $provider = VideoProvider::getProvider( $video->Provider );
 

--- a/tests/GalleryVideoTest.php
+++ b/tests/GalleryVideoTest.php
@@ -7,6 +7,7 @@ use NSWDPC\Elemental\Models\FeaturedVideo\YouTube;
 use NSWDPC\Elemental\Models\FeaturedVideo\Vimeo;
 use NSWDPC\Elemental\Models\FeaturedVideo\YouTubeNoCookie;
 use NSWDPC\Elemental\Models\FeaturedVideo\VideoProvider;
+use SilverStripe\Control\Director;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\ValidationException;
 
@@ -14,6 +15,8 @@ use SilverStripe\ORM\ValidationException;
  * Provide tests for a single gallery video
  */
 class GalleryVideoTest extends SapphireTest {
+
+    protected $usesDatabase =  true;
 
     public function testValidationWrite() {
         try {
@@ -50,12 +53,15 @@ class GalleryVideoTest extends SapphireTest {
 
     public function testYouTube() {
 
+        $videoId = "CyHMQ6iS3rY";
+
         $video = GalleryVideo::create();
         $video->Provider = GalleryVideo::PROVIDER_YOUTUBE;
-        $video->Video = "testyoutube";
+        $video->Video = $videoId;
         $video->Title = "YouTube Test";
         $video->Description = "YouTube Description";
         $video->Transcript = "<p>YouTube Transcript</p>";
+        $video->UseVideoThumbnail = 1;
         $video->write();
 
         $provider = VideoProvider::getProvider( $video->Provider );
@@ -70,7 +76,7 @@ class GalleryVideoTest extends SapphireTest {
 
         $this->assertEquals("www.youtube.com", $parts['host']);
         $this->assertEquals("https", $parts['scheme']);
-        $this->assertEquals("/embed/testyoutube/", $parts['path']);
+        $this->assertEquals("/embed/{$videoId}/", $parts['path']);
 
         $this->assertNotEmpty($parts['query']);
 
@@ -80,7 +86,9 @@ class GalleryVideoTest extends SapphireTest {
             "autoplay" => 0,
             "modestbranding" => 0,
             "fs" => 1,
-            "rel" => 0
+            "rel" => 0,
+            "enablejsapi" => 1,
+            "origin" => Director::protocolAndHost()
         ];
 
         asort($query);
@@ -88,13 +96,18 @@ class GalleryVideoTest extends SapphireTest {
 
         $this->assertEquals( $expected, $query );
 
+        // validate the video has a thumbnail as a URL
+        $this->assertNotFalse( filter_var( $video->VideoThumbnail, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED ) );
+
     }
 
     public function testYouTubeNoCookie() {
 
+        $videoId = "vRl_jDVF-eo";
+
         $video = GalleryVideo::create();
         $video->Provider = GalleryVideo::PROVIDER_YOUTUBE_NOCOOKIE;
-        $video->Video = "testyoutube-nocookie";
+        $video->Video = $videoId;
         $video->Title = "YouTube NoCookie Test";
         $video->Description = "YouTube NoCookie Description";
         $video->Transcript = "<p>YouTube NoCookie Transcript</p>";
@@ -112,7 +125,7 @@ class GalleryVideoTest extends SapphireTest {
 
         $this->assertEquals("www.youtube-nocookie.com", $parts['host']);
         $this->assertEquals("https", $parts['scheme']);
-        $this->assertEquals("/embed/testyoutube-nocookie/", $parts['path']);
+        $this->assertEquals("/embed/{$videoId}/", $parts['path']);
 
         $this->assertNotEmpty($parts['query']);
 
@@ -122,7 +135,9 @@ class GalleryVideoTest extends SapphireTest {
             "autoplay" => 0,
             "modestbranding" => 0,
             "fs" => 1,
-            "rel" => 0
+            "rel" => 0,
+            "enablejsapi" => 1,
+            "origin" => Director::protocolAndHost()
         ];
 
         asort($query);
@@ -130,13 +145,18 @@ class GalleryVideoTest extends SapphireTest {
 
         $this->assertEquals( $expected, $query );
 
+        // validate the video has a thumbnail as a URL
+        $this->assertNotFalse( filter_var( $video->VideoThumbnail, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED ) );
+
     }
 
     public function testVimeo() {
 
+        $videoId = "700166879";
+
         $video = GalleryVideo::create();
         $video->Provider = GalleryVideo::PROVIDER_VIMEO;
-        $video->Video = "testvimeo";
+        $video->Video = $videoId;
         $video->Title = "Vimeo Test";
         $video->Description = "Vimeo Description";
         $video->Transcript = "<p>Vimeo Transcript</p>";
@@ -154,7 +174,7 @@ class GalleryVideoTest extends SapphireTest {
 
         $this->assertEquals("player.vimeo.com", $parts['host']);
         $this->assertEquals("https", $parts['scheme']);
-        $this->assertEquals("/video/testvimeo/", $parts['path']);
+        $this->assertEquals("/video/{$videoId}/", $parts['path']);
 
         $this->assertNotEmpty($parts['query']);
 
@@ -175,6 +195,9 @@ class GalleryVideoTest extends SapphireTest {
         asort($expected);
 
         $this->assertEquals( $expected, $query );
+
+        // validate the video has a thumbnail as a URL
+        $this->assertNotFalse( filter_var( $video->VideoThumbnail, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED ) );
 
     }
 }


### PR DESCRIPTION
## Changes

+ Require minimum silverstripe/framework:^4.10.0
+ Support embed/embed 3 or 4
+ New: automate video thumbnail retrieval via embed/embed
+ Add `enablejsapi` and `origin` to YT video URL
+ NEW: return a video provider code from the container, for use in templates