### PR TITLE
Provider requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,17 @@ This module provides two content elements for us in an elemental area
 + Basic templates, override these in your own project
 + Transcript, description, link fields
 + Image thumbnails for video placeholders
++ Your developer can override the default templates (required)
 
 ## Installation
 
 ```
 composer require nswdpc/silverstripe-elemental-feature-video
 ```
+
+## Documentation
+
++ [Templates and styling hints](./docs/en/001_index.md)
 
 ## License
 
@@ -33,6 +38,10 @@ composer require nswdpc/silverstripe-elemental-feature-video
 We welcome bug reports, pull requests and feature requests on the Github Issue tracker for this project.
 
 Please review the [code of conduct](./code-of-conduct.md) prior to opening a new issue.
+
+## Security
+
+If you have found a security issue with this module, please email digital[@]dpc.nsw.gov.au in the first instance, detailing your findings.
 
 ## Development and contribution
 

--- a/docs/en/001_index.md
+++ b/docs/en/001_index.md
@@ -1,1 +1,26 @@
 # Documentation
+
+## Templates
+
+The templates provided with this module only provide a starting point to get you going within your own site's theme.
+
+Your developer should override these within the project's theme using [the standard Silverstripe theming standards](https://docs.silverstripe.org/en/5/developer_guides/templates/template_inheritance/#cascading-themes).
+
+Use the variables in the templates provided to define your own templates and layout.
+
+
+### Video aspect ratio
+
+You will probably want to set an aspect ratio for iframe elements containing videos. The CSS `aspect-ratio` directive can be used for this:
+
+```css
+.embed.video > iframe,
+.embed.video > video {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    aspect-ratio: 16/9;
+}
+```
+
+This is an improved, simpler method than the older methods using 56.25% top padding with absolute positioning.

--- a/src/Models/Elements/ElementFeaturedVideo.php
+++ b/src/Models/Elements/ElementFeaturedVideo.php
@@ -271,4 +271,13 @@ class ElementFeaturedVideo extends ElementContent implements VideoDefaults {
         return $fields;
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function forTemplate($holder = true)
+    {
+        $this->addEmbedRequirements();
+        return parent::forTemplate($holder);
+    }
+
 }

--- a/src/Models/GalleryVideo.php
+++ b/src/Models/GalleryVideo.php
@@ -338,6 +338,7 @@ class GalleryVideo extends DataObject implements VideoDefaults {
      * Render this record into a template
      */
     public function forTemplate() {
+        $this->addEmbedRequirements();
         return $this->renderWith([$this->class, __CLASS__]);
     }
 

--- a/src/Models/VideoProvider.php
+++ b/src/Models/VideoProvider.php
@@ -38,6 +38,14 @@ abstract class VideoProvider {
 
     abstract public function getWatchURL(string $videoID, array $customQueryArgs) : string;
 
+
+    /**
+     * Optional JS/CSS requirements for provider
+     */
+    public function addEmbedRequirements() : bool {
+        return false;
+    }
+
     /**
      * Return the available providers, subclasses of this class
      */

--- a/src/Models/YouTube.php
+++ b/src/Models/YouTube.php
@@ -3,12 +3,22 @@
 namespace NSWDPC\Elemental\Models\FeaturedVideo;
 
 use Silverstripe\Control\Director;
+use SilverStripe\View\Requirements;
 
 /**
  * YouTube provider, based on https://developers.google.com/youtube/player_parameters
  * @author James
  */
 class YouTube extends VideoProvider {
+
+
+    /**
+     * @var bool
+     * @config
+     * Whether to enable (and require) the YT iframe API
+     * See: https://developers.google.com/youtube/iframe_api_reference
+     */
+    private static $enable_iframe_api = true;
 
     /**
      * Return ident code for this video, used to load an instance of this class
@@ -58,6 +68,23 @@ class YouTube extends VideoProvider {
             "fs" => 1,
             "rel" => 0 // show related videos from the same channel
         ];
+    }
+
+    /**
+     * Include the YT iframe API (if enabled)
+     */
+    public function addEmbedRequirements() : bool {
+        if(!self::config()->get('enable_iframe_api')) {
+            return false;
+        } else {
+            Requirements::javascript(
+                "https://www.youtube.com/iframe_api",
+                [
+                    "async" => true,
+                ]
+            );
+            return true;
+        }
     }
 
     /**

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -71,33 +71,6 @@ trait VideoFromProvider {
     }
 
     /**
-     * Apply CSS requirements
-     */
-    protected function applyRequirements() {
-        $height = $this->getVideoHeight();
-        Requirements::customCSS(
-<<<CSS
-.embed.video {
-    position: relative;
-    overflow: hidden;
-    padding-top: 56.25%;/* 16:9 */
-    height : {$height}px;
-}
-
-.embed.video > iframe {
-    border: 0;
-    height: 100% !important;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-}
-CSS,
-            'galleryVideoEmbedCSS'
-        );
-    }
-
-    /**
      * Method to wrap retrieval of the video id code
      */
     public function getVideoid() {

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -105,10 +105,19 @@ CSS,
     }
 
     /**
+     * Add an requirements used by the video provider to support video embedding
+     */
+    protected function addEmbedRequirements() : void {
+        if($provider = VideoProvider::getProvider( $this->Provider )) {
+            // Add any provider requirements
+            $provider->addEmbedRequirements();
+        }
+    }
+
+    /**
      * Return the URL to embed the video in an <iframe>
      */
     public function EmbedURL() : string {
-        $this->applyRequirements();
         $provider = VideoProvider::getProvider( $this->Provider );
         if($provider) {
             return $provider->getEmbedURL( $this->getVideoid(), [], $this->getVideoHeight() );

--- a/templates/NSWDPC/Elemental/Models/FeaturedVideo/GalleryVideo.ss
+++ b/templates/NSWDPC/Elemental/Models/FeaturedVideo/GalleryVideo.ss
@@ -1,17 +1,17 @@
 <figure>
 
     <div class="embed video">
-    <% if $UseVideoThumbnail == 1 %>
+    <% if $UseVideoThumbnail == 1 && $VideoThumbnail %>
         <% if $WatchURL %><a href="{$WatchURL}" rel="noopener"><% end_if %>
         <% if $VideoThumbnail %>
         <img src="{$VideoThumbnail}" class="video-thumbnail" referrerpolicy="no-referrer" loading="lazy">
         <% end_if %>
         <% if $WatchURL %></a><% end_if %>
-    <% else if $UseVideoThumbnail == 0 %>
+    <% else_if $UseVideoThumbnail == 0 && $Image %>
         <% if $WatchURL %><a href="{$WatchURL}" rel="noopener"><% end_if %>
-        {$Image.ScaleWidth(720)
+        {$Image.ScaleWidth(720)}
         <% if $WatchURL %></a><% end_if %>
-    <% else if $EmbedURL %>
+    <% else_if $EmbedURL %>
         <% include NSWDPC/Elemental/Models/FeaturedVideo/Iframe EmbedURL=$EmbedURL, Anchor=$Parent.Anchor, ID=$ID, AllowAttribute=$AllowAttribute %>
     <% else %>
         <!-- no URL or thumbnail for this video was found -->


### PR DESCRIPTION
## Changes

+ Allow video providers to set specific requirements
+ Youtube loads the iframe_api requirements by default (turn off via config)
+ Remove default styles provided by `applyRequirements` method, update documentation with hints
+ Improve default templates, update documentation with information about overriding
