### PR TITLE
Support parameters in query strings for videos

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "silverstripe/assets" : "^2",
         "silverstripe/asset-admin" : "^2",
         "silverstripe/versioned": "^2",
-        "nswdpc/silverstripe-inline-linker": "^1"
+        "nswdpc/silverstripe-inline-linker": "^1",
+        "symbiote/silverstripe-multivaluefield": "^6"
     },
     "require-dev": {
         "cambis/silverstan": "^2",

--- a/src/Models/Elements/ElementFeaturedVideo.php
+++ b/src/Models/Elements/ElementFeaturedVideo.php
@@ -10,9 +10,9 @@ use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\OptionsetField;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
+use Symbiote\MultiValueField\Fields\KeyValueField;
 use gorriecoe\Link\Models\Link;
 use NSWDPC\InlineLinker\InlineLinkCompositeField;
-use Symbiote\MultiValueField\Fields\KeyValueField;
 
 /**
  * ElementFeaturedVideo adds a featured video
@@ -195,7 +195,6 @@ class ElementFeaturedVideo extends ElementContent implements VideoDefaults
                         'Video ID'
                     )
                 ),
-
                 InlineLinkCompositeField::create(
                     'FeatureLink',
                     _t(
@@ -261,7 +260,6 @@ class ElementFeaturedVideo extends ElementContent implements VideoDefaults
         );
 
 
-        # Extract the query parameters from the DB text
         $fields->insertAfter('VideoID', 
             KeyValueField::create(
                 'CustomQueryArgs',

--- a/src/Models/Elements/ElementFeaturedVideo.php
+++ b/src/Models/Elements/ElementFeaturedVideo.php
@@ -25,6 +25,7 @@ use NSWDPC\InlineLinker\InlineLinkCompositeField;
  * @property int $FeatureLinkID
  * @method \SilverStripe\Assets\Image Image()
  * @method \gorriecoe\Link\Models\Link FeatureLink()
+ * @property mixed[] $CustomQueryArgs
  */
 class ElementFeaturedVideo extends ElementContent implements VideoDefaults
 {

--- a/src/Models/Elements/ElementFeaturedVideo.php
+++ b/src/Models/Elements/ElementFeaturedVideo.php
@@ -12,6 +12,7 @@ use SilverStripe\Forms\OptionsetField;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use gorriecoe\Link\Models\Link;
 use NSWDPC\InlineLinker\InlineLinkCompositeField;
+use Symbiote\MultiValueField\Fields\KeyValueField;
 
 /**
  * ElementFeaturedVideo adds a featured video
@@ -55,7 +56,8 @@ class ElementFeaturedVideo extends ElementContent implements VideoDefaults
         'Provider' => 'Varchar',
         'Width' => 'Int',
         'Height' => 'Int',
-        'Transcript' => 'HTMLText'
+        'Transcript' => 'HTMLText',
+        'CustomQueryArgs' => 'Text',
     ];
 
     private static array $has_one = [
@@ -193,6 +195,7 @@ class ElementFeaturedVideo extends ElementContent implements VideoDefaults
                         'Video ID'
                     )
                 ),
+
                 InlineLinkCompositeField::create(
                     'FeatureLink',
                     _t(
@@ -253,6 +256,18 @@ class ElementFeaturedVideo extends ElementContent implements VideoDefaults
                 _t(
                     self::class . '.TRANSCRIPT',
                     'Transcript of video'
+                )
+            )
+        );
+
+
+        # Extract the query parameters from the DB text
+        $fields->insertAfter('VideoID', 
+            KeyValueField::create(
+                'CustomQueryArgs',
+                _t(
+                    self::class . 'CUSTOM_QUERY_ARGS',
+                    'Custom URL Parameters'
                 )
             )
         );

--- a/src/Models/Elements/ElementFeaturedVideo.php
+++ b/src/Models/Elements/ElementFeaturedVideo.php
@@ -261,7 +261,8 @@ class ElementFeaturedVideo extends ElementContent implements VideoDefaults
         );
 
 
-        $fields->insertAfter('VideoID', 
+        $fields->insertAfter(
+            'VideoID',
             KeyValueField::create(
                 'CustomQueryArgs',
                 _t(

--- a/src/Models/Elements/ElementFeaturedVideo.php
+++ b/src/Models/Elements/ElementFeaturedVideo.php
@@ -266,7 +266,7 @@ class ElementFeaturedVideo extends ElementContent implements VideoDefaults
             KeyValueField::create(
                 'CustomQueryArgs',
                 _t(
-                    self::class . 'CUSTOM_QUERY_ARGS',
+                    self::class . '.CUSTOM_QUERY_ARGS',
                     'Custom URL Parameters'
                 )
             )

--- a/src/Models/Elements/ElementFeaturedVideo.php
+++ b/src/Models/Elements/ElementFeaturedVideo.php
@@ -25,7 +25,7 @@ use NSWDPC\InlineLinker\InlineLinkCompositeField;
  * @property int $FeatureLinkID
  * @method \SilverStripe\Assets\Image Image()
  * @method \gorriecoe\Link\Models\Link FeatureLink()
- * @property mixed[] $CustomQueryArgs
+ * @property mixed $CustomQueryArgs
  */
 class ElementFeaturedVideo extends ElementContent implements VideoDefaults
 {

--- a/src/Models/Elements/ElementFeaturedVideo.php
+++ b/src/Models/Elements/ElementFeaturedVideo.php
@@ -79,6 +79,8 @@ class ElementFeaturedVideo extends ElementContent implements VideoDefaults
 
     private static int $default_thumb_height = 0;
 
+    private static bool $inline_editable = false;
+
     /**
      * Default height of video, if none specified
      * @var int

--- a/src/Models/Elements/ElementFeaturedVideo.php
+++ b/src/Models/Elements/ElementFeaturedVideo.php
@@ -58,7 +58,7 @@ class ElementFeaturedVideo extends ElementContent implements VideoDefaults
         'Width' => 'Int',
         'Height' => 'Int',
         'Transcript' => 'HTMLText',
-        'CustomQueryArgs' => 'Text',
+        'CustomQueryArgs' => 'MultiValueField',
     ];
 
     private static array $has_one = [

--- a/src/Models/Elements/ElementVideoGallery.php
+++ b/src/Models/Elements/ElementVideoGallery.php
@@ -131,7 +131,7 @@ class ElementVideoGallery extends ElementContent
     }
 
 
-    public function SortedVideos()
+    public function SortedVideos(): \SilverStripe\ORM\DataList
     {
         return $this->Videos()->Sort('Sort');
     }

--- a/src/Models/GalleryVideo.php
+++ b/src/Models/GalleryVideo.php
@@ -34,6 +34,7 @@ use NSWDPC\InlineLinker\InlineLinkCompositeField;
  * @method \NSWDPC\Elemental\Models\FeaturedVideo\ElementVideoGallery Parent()
  * @method \gorriecoe\Link\Models\Link LinkTarget()
  * @mixin \SilverStripe\Versioned\Versioned
+ * @property mixed[] $CustomQueryArgs
  */
 class GalleryVideo extends DataObject implements VideoDefaults
 {

--- a/src/Models/GalleryVideo.php
+++ b/src/Models/GalleryVideo.php
@@ -34,7 +34,7 @@ use NSWDPC\InlineLinker\InlineLinkCompositeField;
  * @method \NSWDPC\Elemental\Models\FeaturedVideo\ElementVideoGallery Parent()
  * @method \gorriecoe\Link\Models\Link LinkTarget()
  * @mixin \SilverStripe\Versioned\Versioned
- * @property mixed[] $CustomQueryArgs
+ * @property mixed $CustomQueryArgs
  */
 class GalleryVideo extends DataObject implements VideoDefaults
 {

--- a/src/Models/GalleryVideo.php
+++ b/src/Models/GalleryVideo.php
@@ -310,7 +310,7 @@ class GalleryVideo extends DataObject implements VideoDefaults
             KeyValueField::create(
                 'CustomQueryArgs',
                 _t(
-                    self::class . 'CUSTOM_QUERY_ARGS',
+                    self::class . '.CUSTOM_QUERY_ARGS',
                     'Custom URL Parameters'
                 )
             )

--- a/src/Models/GalleryVideo.php
+++ b/src/Models/GalleryVideo.php
@@ -305,7 +305,8 @@ class GalleryVideo extends DataObject implements VideoDefaults
             )
         );
 
-        $fields->insertAfter('VideoID', 
+        $fields->insertAfter(
+            'VideoID',
             KeyValueField::create(
                 'CustomQueryArgs',
                 _t(

--- a/src/Models/GalleryVideo.php
+++ b/src/Models/GalleryVideo.php
@@ -80,7 +80,7 @@ class GalleryVideo extends DataObject implements VideoDefaults
         'Transcript' => 'HTMLText',
         'VideoThumbnail' => 'Varchar(255)',
         'UseVideoThumbnail' => 'Boolean',
-        'CustomQueryArgs' => 'Text'
+        'CustomQueryArgs' => 'MultiValueField',
     ];
 
     private static array $has_one = [

--- a/src/Models/GalleryVideo.php
+++ b/src/Models/GalleryVideo.php
@@ -13,9 +13,9 @@ use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\Forms\OptionsetField;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
+use Symbiote\MultiValueField\Fields\KeyValueField;
 use gorriecoe\Link\Models\Link;
 use NSWDPC\InlineLinker\InlineLinkCompositeField;
-use Symbiote\MultiValueField\Fields\KeyValueField;
 
 /**
  * Images in an ElementVideo

--- a/src/Models/GalleryVideo.php
+++ b/src/Models/GalleryVideo.php
@@ -15,6 +15,7 @@ use SilverStripe\Forms\OptionsetField;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use gorriecoe\Link\Models\Link;
 use NSWDPC\InlineLinker\InlineLinkCompositeField;
+use Symbiote\MultiValueField\Fields\KeyValueField;
 
 /**
  * Images in an ElementVideo
@@ -77,7 +78,8 @@ class GalleryVideo extends DataObject implements VideoDefaults
         'Sort' => 'Int',
         'Transcript' => 'HTMLText',
         'VideoThumbnail' => 'Varchar(255)',
-        'UseVideoThumbnail' => 'Boolean'
+        'UseVideoThumbnail' => 'Boolean',
+        'CustomQueryArgs' => 'Text'
     ];
 
     private static array $has_one = [
@@ -299,6 +301,16 @@ class GalleryVideo extends DataObject implements VideoDefaults
                     0 => _t(self::class . 'IMAGE_UPLOADED', 'Image uploaded'),
                     1 => _t(self::class . 'VIDEO_THUMBNAIL_FOUND', 'Video thumbnail found')
                 ]
+            )
+        );
+
+        $fields->insertAfter('VideoID', 
+            KeyValueField::create(
+                'CustomQueryArgs',
+                _t(
+                    self::class . 'CUSTOM_QUERY_ARGS',
+                    'Custom URL Parameters'
+                )
             )
         );
 

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -79,7 +79,7 @@ trait VideoFromProvider
         return $this->Video;
     }
 
-    /* 
+    /*
      * Methods for decoding and encoding the array of custom query args into json
      */
     public function getCustomQueryArgs(): array
@@ -124,7 +124,7 @@ trait VideoFromProvider
     {
         $provider = VideoProvider::getProvider($this->Provider);
         if ($provider instanceof \NSWDPC\Elemental\Models\FeaturedVideo\VideoProvider) {
-            return $provider->getEmbedURL($this->getVideoid(),$this->getCustomQueryArgs(), $this->getVideoHeight());
+            return $provider->getEmbedURL($this->getVideoid(), $this->getCustomQueryArgs(), $this->getVideoHeight());
         } else {
             return "";
         }

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -6,6 +6,8 @@ use Embed\Embed;
 use Embed\Extractor;
 use SilverStripe\View\Requirements;
 
+use Symbiote\MultiValueField;
+
 /**
  * Common methods for sourcing a video from a provider
  * @author James
@@ -79,32 +81,6 @@ trait VideoFromProvider
         return $this->Video;
     }
 
-    /*
-     * Methods for decoding and encoding the array of custom query args into json
-     */
-    public function getCustomQueryArgs(): array
-    {
-        $raw = $this->getField('CustomQueryArgs');
-        if (!isset($raw)) {
-            return [];
-        }
-
-        $decoded = json_decode($raw, true);
-        return is_array($decoded) ? $decoded : [];
-    }
-
-    public function setCustomQueryArgs(array $value): self
-    {
-        if (is_array($value)) {
-            $this->setField('CustomQueryArgs', json_encode($value));
-        } elseif (!isset($value)) {
-            // Do nothing
-        } else {
-            error_log('setCustomQueryArgs invalid value');
-        }
-
-        return $this;
-    }
 
     /**
      * Add an requirements used by the video provider to support video embedding
@@ -117,6 +93,18 @@ trait VideoFromProvider
         }
     }
 
+    /*
+     * Get custom query arguments from the MultiValueField
+     */
+    private function getQueries(): array
+    {
+        if (!isset($this->CustomQueryArgs)) {
+            return [];
+        } else {
+            return $this->CustomQueryArgs->getValues() ?? [];
+        }
+    }
+
     /**
      * Return the URL to embed the video in an <iframe>
      */
@@ -124,7 +112,7 @@ trait VideoFromProvider
     {
         $provider = VideoProvider::getProvider($this->Provider);
         if ($provider instanceof \NSWDPC\Elemental\Models\FeaturedVideo\VideoProvider) {
-            return $provider->getEmbedURL($this->getVideoid(), $this->getCustomQueryArgs(), $this->getVideoHeight());
+            return $provider->getEmbedURL($this->getVideoid(), $this->getQueries(), $this->getVideoHeight());
         } else {
             return "";
         }
@@ -137,7 +125,7 @@ trait VideoFromProvider
     {
         $provider = VideoProvider::getProvider($this->Provider);
         if ($provider instanceof \NSWDPC\Elemental\Models\FeaturedVideo\VideoProvider) {
-            return $provider->getWatchURL($this->getVideoid(), $this->getCustomQueryArgs());
+            return $provider->getWatchURL($this->getVideoid(), $this->getQueries());
         } else {
             return "";
         }

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -107,7 +107,7 @@ trait VideoFromProvider
         $result = $this->dbObject('CustomQueryArgs');
         if ($result instanceof KeyValueField) {
             return $result->getValue() ?? [];
-        }  else {
+        } else {
             return [];
         }
     }

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -80,7 +80,7 @@ trait VideoFromProvider
     }
 
     /* 
-     * Method to wrap retrieval of custom query args
+     * Methods for decoding and encoding the array of custom query args into json
      */
     public function getCustomQueryArgs(): array
     {

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -6,6 +6,7 @@ use Embed\Embed;
 use Embed\Extractor;
 use SilverStripe\View\Requirements;
 use Symbiote\MultiValueField;
+use Symbiote\MultiValueField\Fields\KeyValueField;
 
 /**
  * Common methods for sourcing a video from a provider
@@ -97,10 +98,18 @@ trait VideoFromProvider
      */
     private function getQueries(): array
     {
-        if (!isset($this->CustomQueryArgs)) {
+        /*if (!isset($this->CustomQueryArgs)) {
             return [];
         } else {
             return $this->CustomQueryArgs->getValues() ?? [];
+        }*/
+
+        $result = $this->dbObject('CustomQueryArgs');
+        if ($result instanceof KeyValueField) {
+            $value = $result->getValue() ?? [];
+            return $value;
+        }  else {
+            return [];
         }
     }
 

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -102,6 +102,7 @@ trait VideoFromProvider
         } else {
             error_log('setCustomQueryArgs invalid value');
         }
+
         return $this;
     }
 

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -79,6 +79,32 @@ trait VideoFromProvider
         return $this->Video;
     }
 
+    /* 
+     * Method to wrap retrieval of custom query args
+     */
+    public function getCustomQueryArgs(): array
+    {
+        $raw = $this->getField('CustomQueryArgs');
+        if (!isset($raw)) {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    public function setCustomQueryArgs(array $value): self
+    {
+        if (is_array($value)) {
+            $this->setField('CustomQueryArgs', json_encode($value));
+        } elseif (!isset($value)) {
+            // Do nothing
+        } else {
+            error_log('setCustomQueryArgs invalid value');
+        }
+        return $this;
+    }
+
     /**
      * Add an requirements used by the video provider to support video embedding
      */
@@ -97,7 +123,7 @@ trait VideoFromProvider
     {
         $provider = VideoProvider::getProvider($this->Provider);
         if ($provider instanceof \NSWDPC\Elemental\Models\FeaturedVideo\VideoProvider) {
-            return $provider->getEmbedURL($this->getVideoid(), [], $this->getVideoHeight());
+            return $provider->getEmbedURL($this->getVideoid(),$this->getCustomQueryArgs(), $this->getVideoHeight());
         } else {
             return "";
         }
@@ -110,7 +136,7 @@ trait VideoFromProvider
     {
         $provider = VideoProvider::getProvider($this->Provider);
         if ($provider instanceof \NSWDPC\Elemental\Models\FeaturedVideo\VideoProvider) {
-            return $provider->getWatchURL($this->getVideoid(), []);
+            return $provider->getWatchURL($this->getVideoid(), $this->getCustomQueryArgs());
         } else {
             return "";
         }

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -5,7 +5,6 @@ namespace NSWDPC\Elemental\Models\FeaturedVideo;
 use Embed\Embed;
 use Embed\Extractor;
 use SilverStripe\View\Requirements;
-
 use Symbiote\MultiValueField;
 
 /**

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -5,8 +5,7 @@ namespace NSWDPC\Elemental\Models\FeaturedVideo;
 use Embed\Embed;
 use Embed\Extractor;
 use SilverStripe\View\Requirements;
-use Symbiote\MultiValueField;
-use Symbiote\MultiValueField\Fields\KeyValueField;
+use Symbiote\MultiValueField\ORM\FieldType\MultiValueField;
 
 /**
  * Common methods for sourcing a video from a provider
@@ -98,14 +97,8 @@ trait VideoFromProvider
      */
     private function getQueries(): array
     {
-        /*if (!isset($this->CustomQueryArgs)) {
-            return [];
-        } else {
-            return $this->CustomQueryArgs->getValues() ?? [];
-        }*/
-
         $result = $this->dbObject('CustomQueryArgs');
-        if ($result instanceof KeyValueField) {
+        if ($result instanceof MultiValueField) {
             return $result->getValue() ?? [];
         } else {
             return [];

--- a/src/Traits/VideoFromProvider.php
+++ b/src/Traits/VideoFromProvider.php
@@ -106,8 +106,7 @@ trait VideoFromProvider
 
         $result = $this->dbObject('CustomQueryArgs');
         if ($result instanceof KeyValueField) {
-            $value = $result->getValue() ?? [];
-            return $value;
+            return $result->getValue() ?? [];
         }  else {
             return [];
         }

--- a/tests/ElementFeaturedVideoTest.php
+++ b/tests/ElementFeaturedVideoTest.php
@@ -245,7 +245,6 @@ class ElementFeaturedVideoTest extends SapphireTest
         $url = $video->EmbedURL();
         $url_parsed = parse_url($url);
         parse_str($url_parsed['query'], $query);
-        error_log("Parameters: " . print_r($query, true));
 
         $this->assertArrayHasKey('h', $query);
         $this->assertArrayHasKey('t', $query);

--- a/tests/ElementFeaturedVideoTest.php
+++ b/tests/ElementFeaturedVideoTest.php
@@ -10,6 +10,8 @@ use NSWDPC\Elemental\Models\FeaturedVideo\ElementFeaturedVideo;
 use SilverStripe\Control\Director;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\ValidationException;
+use Symbiote\MultiValueField\Fields\KeyValueField;
+use Symbiote\MultiValueField\ORM\FieldType\MultiValueField;
 
 /**
  * Provide tests for element featured video
@@ -236,12 +238,16 @@ class ElementFeaturedVideoTest extends SapphireTest
         $video->Title = "Vimeo Test";
         $video->Description = "Vimeo Description";
         $video->Transcript = "<p>Vimeo Transcript</p>";
-        $video->CustomQueryArgs = [ "h" => "1", "t" => "10min" ];
+        $video->CustomQueryArgs = [
+            "h" => "1",
+            "t" => "10min"
+        ];
         $video->write();
 
         $url = $video->EmbedURL();
         $url_parsed = parse_url($url);
         parse_str($url_parsed['query'], $query);
+        error_log("Parameters: " . print_r($query, true));
 
         $this->assertArrayHasKey('h', $query);
         $this->assertArrayHasKey('t', $query);

--- a/tests/ElementFeaturedVideoTest.php
+++ b/tests/ElementFeaturedVideoTest.php
@@ -228,7 +228,8 @@ class ElementFeaturedVideoTest extends SapphireTest
 
     }
 
-    public function testEmbedURL(): void {
+    public function testEmbedURL(): void
+    {
         $video = ElementFeaturedVideo::create();
         $video->Provider = Vimeo::getProviderCode();
         $video->Video = "testvimeo";

--- a/tests/ElementFeaturedVideoTest.php
+++ b/tests/ElementFeaturedVideoTest.php
@@ -228,4 +228,24 @@ class ElementFeaturedVideoTest extends SapphireTest
 
     }
 
+    public function testEmbedURL(): void {
+        $video = ElementFeaturedVideo::create();
+        $video->Provider = Vimeo::getProviderCode();
+        $video->Video = "testvimeo";
+        $video->Title = "Vimeo Test";
+        $video->Description = "Vimeo Description";
+        $video->Transcript = "<p>Vimeo Transcript</p>";
+        $video->CustomQueryArgs = [ "h" => "1", "t" => "10min" ];
+        $video->write();
+
+        $url = $video->EmbedURL();
+        $url_parsed = parse_url($url);
+        parse_str($url_parsed['query'], $query);
+
+        $this->assertArrayHasKey('h', $query);
+        $this->assertArrayHasKey('t', $query);
+
+        $this->assertEquals('1', $query['h']);
+        $this->assertEquals('10min', $query['t']);
+    }
 }

--- a/tests/ElementFeaturedVideoTest.php
+++ b/tests/ElementFeaturedVideoTest.php
@@ -10,8 +10,6 @@ use NSWDPC\Elemental\Models\FeaturedVideo\ElementFeaturedVideo;
 use SilverStripe\Control\Director;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\ValidationException;
-use Symbiote\MultiValueField\Fields\KeyValueField;
-use Symbiote\MultiValueField\ORM\FieldType\MultiValueField;
 
 /**
  * Provide tests for element featured video


### PR DESCRIPTION
See issue #17 

**Changes**
- Support added for parameters in query strings for GalleryVideo and ElementFeaturedVideo
- Added a test to check if the parameters are included when calling EmbedUrl